### PR TITLE
feat(macro): added `__field!` support to `kv` macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/bigerror"
 repository = "https://github.com/mkatychev/bigerror"
 
 [workspace.dependencies]
-derive_more = { version = "2", features = ["display"], default-features = false }
+derive_more = { version = "2", features = ["display", "deref"], default-features = false }
 tracing = "0.1"
 proc-macro2 = "1.0.101"
 quote = "1.0.40"

--- a/bigerror/Cargo.toml
+++ b/bigerror/Cargo.toml
@@ -33,3 +33,4 @@ workspace = true
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+all-features = true

--- a/bigerror/Cargo.toml
+++ b/bigerror/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bigerror"
-version = "0.10.2"
+version = "0.11.0-alpha"
 edition.workspace = true
 description.workspace = true
 license.workspace = true

--- a/bigerror/Cargo.toml
+++ b/bigerror/Cargo.toml
@@ -30,3 +30,6 @@ derive_more.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/bigerror/Cargo.toml
+++ b/bigerror/Cargo.toml
@@ -33,4 +33,3 @@ workspace = true
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
-all-features = true

--- a/bigerror/src/attachment.rs
+++ b/bigerror/src/attachment.rs
@@ -91,9 +91,6 @@ macro_rules! kv {
     (ty: $value: expr) => {
         $crate::KeyValue($crate::Type::any(&$value), $value)
     };
-    ($value: expr) => {
-        $crate::KeyValue(stringify!($value), $value)
-    };
     ($($body:tt)+) => {
         {
             let (__key, __value)= $crate::__field!($($body)+);
@@ -393,29 +390,26 @@ mod test {
 
     #[test]
     fn kv_macro_var() {
-        // let foo = "Foo";
-        // let attachment = kv!(foo.to_owned());
-        //
-        // assert_eq!(attachment, KeyValue("foo", String::from(foo)));
+        let foo = "Foo";
+        let key_value = kv!(foo.to_owned());
+
+        assert_eq!(key_value, KeyValue("foo", String::from(foo)));
     }
 
     #[test]
     fn kv_macro_struct() {
-        // let my_struct = MyStruct {
-        //     my_field: None,
-        //     _string: String::from("Value"),
-        // };
-        //
-        // let attachment = kv!(my_struct._string);
-        // assert_eq!(attachment, KeyValue("_string", String::from("Value")));
-        // let my_field = expect_field!(my_struct.my_field);
-        // // from field method
-        // let my_field = expect_field!(my_struct.%my_field());
-        // assert_err!(my_field);
-        // let my_field = my_struct.my_field;
-        // let my_field = expect_field!(my_field.to_owned().to_owned());
-        // assert_err!(my_field);
-        //
-        // assert_eq!(attachment, KeyValue("foo", String::from(foo)));
+        let my_struct = MyStruct {
+            my_field: None,
+            _string: String::from("Value"),
+        };
+
+        let key_value = kv!(my_struct.%my_field());
+        assert_eq!(key_value, KeyValue("my_field", None));
+
+        let key_value = kv!(my_struct.%_string);
+        assert_eq!(key_value, KeyValue("_string", String::from("Value")));
+
+        let key_value = kv!(my_struct.my_field);
+        assert_eq!(key_value, KeyValue("my_struct.my_field", None));
     }
 }

--- a/bigerror/src/attachment.rs
+++ b/bigerror/src/attachment.rs
@@ -80,11 +80,6 @@ impl<K: Display, V: Debug> KeyValue<K, Dbg<V>> {
 
 /// Creates a [`KeyValue`] pair for error attachments with flexible key-value syntax.
 ///
-/// This macro provides two forms:
-/// - `kv!(ty: value)` - Uses the type of `value` as the key: `<String>`
-/// - `kv!(type: value)` - Uses the full type of `value` as the key: `<std::str::String>`
-/// - `kv!(expression)` - Extracts field/variable names from expressions
-///
 /// # Examples
 ///
 /// ## Type-based key-value pairs
@@ -94,7 +89,7 @@ impl<K: Display, V: Debug> KeyValue<K, Dbg<V>> {
 ///
 /// let number = 42;
 /// let kv_pair = kv!(ty: number);
-/// assert_eq!(kv_pair, KeyValue(Type::of_val(&number), 42));
+/// assert_eq!(format!("{kv_pair}"), "<i32>: 42");
 /// ```
 ///
 /// ## Field/variable extraction
@@ -108,24 +103,24 @@ impl<K: Display, V: Debug> KeyValue<K, Dbg<V>> {
 ///
 /// #[derive(Clone)]
 /// struct User { name: String }
+/// let user = User { name: "bob".to_string() };
+///
+///
+/// let kv_field = kv!(user.name.clone());
+/// assert_eq!(format!("{kv_field}"), "user.name: bob");
+///
+/// // adding a `%` will use just the field name
+/// let kv_field = kv!(user.%name.clone());
+/// assert_eq!(format!("{kv_field}"), "name: bob");
+///
+/// // `%` works on methods too!
 /// impl User {
 ///     fn name(&self) -> &str {
 ///         self.name.as_str()
 ///     }
 /// }
-/// let user = User { name: "bob".to_string() };
-///
-///
-/// let kv_field = kv!(user.name.clone());
-/// assert_eq!(kv_field, KeyValue("user.name", "bob".to_string()));
-///
-/// // adding a `%` will use just the field name
-/// let kv_field = kv!(user.%name.clone());
-/// assert_eq!(kv_field, KeyValue("name", "bob".to_string()));
-///
-/// // `%` works on methods too!
 /// let kv_field = kv!(user.%name());
-/// assert_eq!(kv_field, KeyValue("name", "bob"));
+/// assert_eq!(format!("{kv_field}"), "name: bob");
 /// ```
 #[macro_export]
 macro_rules! kv {

--- a/bigerror/src/attachment.rs
+++ b/bigerror/src/attachment.rs
@@ -213,9 +213,7 @@ impl fmt::Debug for Type {
 /// The type attachment shows the type name in error messages, which is useful for
 /// debugging type-related issues or showing what types were involved in an operation.
 ///
-/// # Examples
-///
-/// ## Basic type attachments
+/// # Example
 ///
 /// ```
 /// use std::path::PathBuf;
@@ -406,7 +404,7 @@ pub fn hms_string(duration: Duration) -> String {
 /// For generic types like `Option<T>` or `Vec<T>`, it preserves the full
 /// generic syntax.
 ///
-/// # Examples
+/// # Example
 ///
 /// ```
 /// # use bigerror::attachment::simple_type_name;

--- a/bigerror/src/attachment.rs
+++ b/bigerror/src/attachment.rs
@@ -132,6 +132,9 @@ impl<K: Display, V: Debug> KeyValue<K, Dbg<V>> {
 #[macro_export]
 macro_rules! kv {
     (ty: $value: expr) => {
+        $crate::KeyValue($crate::Type::of(&$value), $value)
+    };
+    (type: $value: expr) => {
         $crate::KeyValue($crate::Type::any(&$value), $value)
     };
     ($($body:tt)+) => {

--- a/bigerror/src/attachment.rs
+++ b/bigerror/src/attachment.rs
@@ -78,12 +78,6 @@ impl<K: Display, V: Debug> KeyValue<K, Dbg<V>> {
     }
 }
 
-impl<V: Display> KeyValue<&'static str, V> {
-    pub const fn __vk(value: V, key: &'static str) -> Self {
-        Self(key, value)
-    }
-}
-
 /// Allows one to quickly specify a [`KeyValue`] pair, optionally using a
 /// `ty:` prefix using the `$value` [`Type`] as the key
 #[macro_export]

--- a/bigerror/src/attachment.rs
+++ b/bigerror/src/attachment.rs
@@ -89,15 +89,15 @@ impl<K: Display, V: Debug> KeyValue<K, Dbg<V>> {
 /// ## Type-based key-value pairs
 ///
 /// ```
-/// use bigerror::{kv, KeyValue, ty};
+/// use bigerror::{kv, KeyValue, attachment::Type};
 ///
 /// let number = 42;
 /// let kv_pair = kv!(ty: number);
-/// assert_eq!(kv_pair, KeyValue(ty!(i32), 42));
+/// assert_eq!(kv_pair, KeyValue(Type::of_val(&number), 42));
 ///
 /// // Works with literals too
 /// let kv_literal = kv!(ty: "hello");
-/// assert_eq!(kv_literal, KeyValue(ty!(&str), "hello"));
+/// assert_eq!(kv_literal, KeyValue(Type::of_val(&"hello"), "hello"));
 /// ```
 ///
 /// ## Field/variable extraction
@@ -132,10 +132,10 @@ impl<K: Display, V: Debug> KeyValue<K, Dbg<V>> {
 #[macro_export]
 macro_rules! kv {
     (ty: $value: expr) => {
-        $crate::KeyValue($crate::Type::of(&$value), $value)
+        $crate::KeyValue($crate::attachment::Type::of_val(&$value), $value)
     };
     (type: $value: expr) => {
-        $crate::KeyValue($crate::Type::any(&$value), $value)
+        $crate::KeyValue($crate::Type::any_val(&$value), $value)
     };
     ($($body:tt)+) => {
         {
@@ -187,12 +187,17 @@ impl Type {
         Self(simple_type_name::<T>())
     }
 
+    #[must_use]
+    pub fn any<T>() -> Self {
+        Self(any::type_name::<T>())
+    }
+
     /// Create a type attachment for the type of the given value.
     pub fn of_val<T: ?Sized>(_val: &T) -> Self {
         Self(simple_type_name::<T>())
     }
     /// Create a type attachment with a fully qualified URI
-    pub fn any<T: ?Sized>(_val: &T) -> Self {
+    pub fn any_val<T: ?Sized>(_val: &T) -> Self {
         Self(any::type_name::<T>())
     }
 }
@@ -270,7 +275,10 @@ impl fmt::Debug for Type {
 #[macro_export]
 macro_rules! ty {
     ($type:ty) => {
-        $crate::attachment::Type::of::<$type>()
+        $crate::Type::of::<$type>()
+    };
+    (full: $type:ty) => {
+        $crate::Type::full::<$type>()
     };
 }
 

--- a/bigerror/src/attachment.rs
+++ b/bigerror/src/attachment.rs
@@ -91,11 +91,14 @@ macro_rules! kv {
     (ty: $value: expr) => {
         $crate::KeyValue($crate::Type::any(&$value), $value)
     };
+    ($value: expr) => {
+        $crate::KeyValue(stringify!($value), $value)
+    };
     ($($body:tt)+) => {
-        $crate::__field!(
-            $crate::KeyValue::__vk |
-            $($body)+
-        )
+        {
+            let (__key, __value)= $crate::__field!($($body)+);
+            $crate::KeyValue(__key, __value)
+        }
     };
 }
 
@@ -369,6 +372,7 @@ pub struct Index<I: fmt::Display>(pub I);
 mod test {
 
     use super::*;
+    use crate::MyStruct;
 
     #[test]
     fn kv_macro() {
@@ -388,10 +392,30 @@ mod test {
     }
 
     #[test]
-    fn kv_macro_field() {
-        let foo = "Foo";
-        let attachment = kv!(foo.to_owned());
+    fn kv_macro_var() {
+        // let foo = "Foo";
+        // let attachment = kv!(foo.to_owned());
+        //
+        // assert_eq!(attachment, KeyValue("foo", String::from(foo)));
+    }
 
-        assert_eq!(attachment, KeyValue("foo", String::from(foo)));
+    #[test]
+    fn kv_macro_struct() {
+        // let my_struct = MyStruct {
+        //     my_field: None,
+        //     _string: String::from("Value"),
+        // };
+        //
+        // let attachment = kv!(my_struct._string);
+        // assert_eq!(attachment, KeyValue("_string", String::from("Value")));
+        // let my_field = expect_field!(my_struct.my_field);
+        // // from field method
+        // let my_field = expect_field!(my_struct.%my_field());
+        // assert_err!(my_field);
+        // let my_field = my_struct.my_field;
+        // let my_field = expect_field!(my_field.to_owned().to_owned());
+        // assert_err!(my_field);
+        //
+        // assert_eq!(attachment, KeyValue("foo", String::from(foo)));
     }
 }

--- a/bigerror/src/lib.rs
+++ b/bigerror/src/lib.rs
@@ -665,6 +665,10 @@ macro_rules! __field {
     ($fn:path, @[$($rf:tt)*] @[$($pre:expr)+], $field:ident $(.$method:ident())* ) => {
         $fn($($rf)*$($pre.)+ $field $(.$method())*, stringify!($field))
     };
+    // handle method calls with any arguments: .method(args...)
+    ($fn:path, @[$($rf:tt)*] @[$($pre:expr)+], $method:ident ( $($args:tt)* ) $(.$rest_method:ident())* ) => {
+        $fn($($rf)*$($pre.)+ $method ( $($args)* ) $(.$rest_method())*, stringify!($method))
+    };
     ($fn:path, @[$($rf:tt)*] @[$body:expr], $(.$method:ident())* ) => {
         $fn($($rf)*$body$(.$method())*, stringify!($body))
     };
@@ -688,6 +692,11 @@ macro_rules! __field {
     };
     ($fn:path | $field:ident) => {
         $fn($field, stringify!($field))
+    };
+
+    // handle expressions with method calls with parentheses (catch-all)
+    ($fn:path | $expr:expr) => {
+        $fn($expr, stringify!($expr))
     };
 }
 
@@ -874,6 +883,9 @@ mod test {
         assert_err!(my_field);
         // from field method
         let my_field = expect_field!(my_struct.%my_field());
+        assert_err!(my_field);
+        let my_field = my_struct.my_field;
+        let my_field = expect_field!(my_field.to_owned().to_owned());
         assert_err!(my_field);
     }
 

--- a/bigerror/src/lib.rs
+++ b/bigerror/src/lib.rs
@@ -23,10 +23,10 @@
 //! struct MyError;
 //!
 //! fn parse_number(input: &str) -> Result<i32, Report<MyError>> {
-//!     // Use context conversion for error handling  
+//!     // Use context conversion for error handling
 //!     let num: i32 = input.parse()
 //!         .map_err(|e| ParseError::attach_kv("input", input.to_string()).into_ctx())?;
-//!     
+//!
 //!     Ok(num)
 //! }
 //!
@@ -106,7 +106,7 @@
 //! Common error contexts are provided out of the box:
 //!
 //! - [`NotFound`] - Missing resources, failed lookups
-//! - [`ParseError`] - Parsing and deserialization failures  
+//! - [`ParseError`] - Parsing and deserialization failures
 //! - [`Timeout`] - Operations that exceed time limits
 //! - [`InvalidInput`] - Validation and input errors
 //! - [`ConversionError`] - Type conversion failures
@@ -827,7 +827,7 @@ where
     /// ```
     /// use bigerror::{OptionReport, IntoContext, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct DatabaseError;
     ///
     /// fn get_config() -> Result<String, Report<DatabaseError>> {

--- a/bigerror/src/lib.rs
+++ b/bigerror/src/lib.rs
@@ -692,7 +692,7 @@ pub trait ResultIntoContext: ResultExt {
     ///
     /// fn count_lines_in_file(path: &str) -> Result<usize, Report<FileError>> {
     ///     std::fs::read_to_string(path)
-    ///         .into_ctx::<FileError>() // Convert std::io::Error to Report<FileError>
+    ///         .into_ctx() // Convert std::io::Error to Report<FileError>
     ///         .map_ctx(|content| content.lines().count()) // Count lines
     /// }
     /// ```

--- a/bigerror/src/lib.rs
+++ b/bigerror/src/lib.rs
@@ -19,7 +19,7 @@
 //! use bigerror::{ThinContext, Report, kv, expect_field, ParseError, IntoContext};
 //!
 //! // Define your error type
-//! #[derive(bigerror::ThinContext)]
+//! #[derive(ThinContext)]
 //! struct MyError;
 //!
 //! fn parse_number(input: &str) -> Result<i32, Report<MyError>> {
@@ -197,7 +197,7 @@ pub fn init_no_ansi() {
 /// ```
 /// use bigerror::{ThinContext, Report};
 ///
-/// #[derive(bigerror::ThinContext)]
+/// #[derive(ThinContext)]
 /// pub struct MyError;
 ///
 /// // Create an error with an attachment
@@ -336,7 +336,7 @@ pub trait ReportAs<T> {
     /// ```
     /// use bigerror::{ReportAs, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct MyError;
     ///
     /// fn parse_number(s: &str) -> Result<i32, Report<MyError>> {
@@ -353,7 +353,7 @@ pub trait ReportAs<T> {
     /// ```
     /// use bigerror::{ReportAs, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ConfigError;
     ///
     /// fn read_config() -> Result<String, Report<ConfigError>> {
@@ -368,7 +368,7 @@ pub trait ReportAs<T> {
     /// ```
     /// use bigerror::{ReportAs, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ProcessingError;
     ///
     /// fn process_data() -> Result<i32, Report<ProcessingError>> {
@@ -387,7 +387,7 @@ pub trait ReportAs<T> {
     /// use bigerror::{ReportAs, ThinContext, Report};
     /// use error_stack::ResultExt;
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct MyError;
     ///
     /// // With report_as() - concise and automatic
@@ -480,10 +480,10 @@ pub trait IntoContext {
     /// ```
     /// use bigerror::{IntoContext, ThinContext, Report, NotFound};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct DatabaseError;
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ServiceError;
     ///
     /// fn fetch_user_data() -> Result<String, Report<ServiceError>> {
@@ -504,7 +504,7 @@ pub trait IntoContext {
     /// ```
     /// use bigerror::{IntoContext, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct MyError;
     ///
     /// fn optimized_conversion() -> Result<(), Report<MyError>> {
@@ -522,10 +522,10 @@ pub trait IntoContext {
     /// ```
     /// use bigerror::{IntoContext, ThinContext, Report, ParseError};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ConfigError;
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct AppError;
     ///
     /// fn load_config() -> Result<i32, Report<ConfigError>> {
@@ -570,7 +570,7 @@ pub trait ResultIntoContext: ResultExt {
     /// ```
     /// use bigerror::{ResultIntoContext, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct MyError;
     ///
     /// fn parse_data() -> Result<i32, Report<MyError>> {
@@ -585,7 +585,7 @@ pub trait ResultIntoContext: ResultExt {
     /// ```
     /// use bigerror::{ResultIntoContext, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ProcessingError;
     ///
     /// fn process_file() -> Result<i32, Report<ProcessingError>> {
@@ -610,10 +610,10 @@ pub trait ResultIntoContext: ResultExt {
     /// ```
     /// use bigerror::{ResultIntoContext, ThinContext, Report, IntoContext};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ValidationError;
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ProcessingError;
     ///
     /// fn validate_and_process(input: &str) -> Result<i32, Report<ProcessingError>> {
@@ -639,7 +639,7 @@ pub trait ResultIntoContext: ResultExt {
     /// ```
     /// use bigerror::{ResultIntoContext, ThinContext, Report, NotFound, IntoContext};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct DatabaseError;
     ///
     /// fn find_user_and_get_email(user_id: u64) -> Result<String, Report<DatabaseError>> {
@@ -677,7 +677,7 @@ pub trait ResultIntoContext: ResultExt {
     /// ```
     /// use bigerror::{ResultIntoContext, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct MyError;
     ///
     /// fn double_parsed_number(input: &str) -> Result<i32, Report<MyError>> {
@@ -695,7 +695,7 @@ pub trait ResultIntoContext: ResultExt {
     /// ```
     /// use bigerror::{ResultIntoContext, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct FileError;
     ///
     /// fn count_lines_in_file(path: &str) -> Result<usize, Report<FileError>> {
@@ -710,7 +710,7 @@ pub trait ResultIntoContext: ResultExt {
     /// ```
     /// use bigerror::{ResultIntoContext, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ProcessingError;
     ///
     /// fn parse_and_format_numbers(input: &str) -> Result<String, Report<ProcessingError>> {
@@ -792,7 +792,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct MyError;
     ///
     /// fn process_user(user_id: u64) -> Result<String, Report<MyError>> {
@@ -812,7 +812,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct FileError;
     ///
     /// fn read_config_file() -> Result<String, Report<FileError>> {
@@ -828,7 +828,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct NetworkError;
     ///
     /// fn make_request(url: &str, timeout_ms: u64) -> Result<String, Report<NetworkError>> {
@@ -859,7 +859,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ValidationError;
     ///
     /// #[derive(Debug)]
@@ -883,7 +883,7 @@ pub trait AttachExt {
     /// use bigerror::{AttachExt, ThinContext, Report};
     /// use std::collections::HashMap;
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ProcessingError;
     ///
     /// fn process_data(data: HashMap<String, i32>) -> Result<i32, Report<ProcessingError>> {
@@ -900,7 +900,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ParseError;
     ///
     /// fn parse_numbers(input: Vec<&str>) -> Result<Vec<i32>, Report<ParseError>> {
@@ -931,7 +931,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report, attachment::Missing};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ValidationError;
     ///
     /// fn validate_user_data(email: Option<&str>, age: Option<u32>) -> Result<(), Report<ValidationError>> {
@@ -962,7 +962,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report, attachment::Invalid};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct DatabaseError;
     ///
     /// fn update_user_record(user_id: u64, email: &str) -> Result<(), Report<DatabaseError>> {
@@ -981,7 +981,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report, attachment::Unsupported};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ConfigError;
     ///
     /// fn load_config(config: &str) -> Result<(), Report<ConfigError>> {
@@ -1011,7 +1011,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ProcessingError;
     ///
     /// #[derive(Debug)]
@@ -1036,7 +1036,7 @@ pub trait AttachExt {
     /// use bigerror::{AttachExt, ThinContext, Report};
     /// use std::collections::HashMap;
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ConfigError;
     ///
     /// fn validate_config(config: HashMap<String, String>) -> Result<(), Report<ConfigError>> {
@@ -1053,7 +1053,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct CalculationError;
     ///
     /// fn complex_calculation(inputs: Vec<f64>) -> Result<f64, Report<CalculationError>> {
@@ -1086,7 +1086,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ProcessingError;
     ///
     /// fn process_count(count: usize) -> Result<String, Report<ProcessingError>> {
@@ -1103,7 +1103,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ValidationError;
     ///
     /// fn validate_inputs(name: String, age: u32, score: f64) -> Result<(), Report<ValidationError>> {
@@ -1122,7 +1122,7 @@ pub trait AttachExt {
     /// ```
     /// use bigerror::{AttachExt, ThinContext, Report};
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct ConversionError;
     ///
     /// fn safe_divide(a: f64, b: f64) -> Result<f64, Report<ConversionError>> {
@@ -1161,7 +1161,7 @@ pub trait AttachExt {
     /// use bigerror::{AttachExt, ThinContext, Report};
     /// use std::path::Path;
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct FileError;
     ///
     /// fn read_config_file<P: AsRef<Path>>(path: P) -> Result<String, Report<FileError>> {
@@ -1177,7 +1177,7 @@ pub trait AttachExt {
     /// use bigerror::{AttachExt, ThinContext, Report};
     /// use std::path::PathBuf;
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct DirectoryError;
     ///
     /// fn create_directory(dir_path: PathBuf) -> Result<(), Report<DirectoryError>> {
@@ -1193,7 +1193,7 @@ pub trait AttachExt {
     /// use bigerror::{AttachExt, ThinContext, Report};
     /// use std::path::Path;
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct BackupError;
     ///
     /// fn backup_file(source: &Path, dest: &Path) -> Result<(), Report<BackupError>> {
@@ -1217,7 +1217,7 @@ pub trait AttachExt {
     /// use bigerror::{AttachExt, ThinContext, Report};
     /// use std::path::Path;
     ///
-    /// #[derive(bigerror::ThinContext)]
+    /// #[derive(ThinContext)]
     /// struct IoError;
     ///
     /// fn process_file(path: &Path) -> Result<String, Report<IoError>> {

--- a/bigerror/src/lib.rs
+++ b/bigerror/src/lib.rs
@@ -1586,7 +1586,7 @@ macro_rules! __field {
         $crate::__field!(
             { $($rest)+ }
             @[]
-            ref[$($ref)* /*add*/ &$($lifetime)? ]
+            ref[$($ref)* /*add*/ &$($lifetime)?]
             var[]
             fns[]
         )
@@ -1596,29 +1596,29 @@ macro_rules! __field {
         $crate::__field!(
             { $($rest)+ }
             @[]
-            ref[$($ref)* /*add*/ * ]
+            ref[$($ref)* /*add*/ *]
             var[]
             fns[]
         )
     };
-    ({ . % $field:ident $($rest:tt)* }
+    ({ .%$field:ident $($rest:tt)* }
         @[] ref[$($ref:tt)*] var[$($var:tt)+] fns[$($fn:tt)*]) => {
         $crate::__field!(
-            { /*add*/ . $field $($rest)* }
+            { /*add*/ .$field $($rest)* }
             @[/*add*/ $field]
             ref[$($ref)*]
             var[$($var)+]
             fns[$($fn)*]
         )
     };
-    ({. $method:ident($($arg:expr)? $(,$tail_args:expr)* ) $($rest:tt)* }
+    ({ .$method:ident($($arg:expr)? $(, $tail_args:expr)*) $($rest:tt)* }
         @[$($field:ident)?] ref[$($ref:tt)*] var[$($var:tt)*] fns[$($fn:tt)*]) => {
         $crate::__field!(
             { $($rest)* }
             @[$($field)?]
             ref[$($ref)*]
             var[$($var)*]
-            fns[$($fn)* /*add*/ . $method($($arg)? $(, $tail_args)*) ]
+            fns[$($fn)* /*add*/ .$method($($arg)? $(, $tail_args)*)]
         )
     };
     ({ .$property:ident $($rest:tt)* }

--- a/bigerror/src/lib.rs
+++ b/bigerror/src/lib.rs
@@ -56,7 +56,7 @@
 //! Attach contextual information to errors using various attachment types:
 //!
 //! ```rust
-//! use bigerror::{ThinContext, kv, ty};
+//! use bigerror::{ThinContext, kv, ty, KeyValue};
 //!
 //! #[derive(ThinContext)]
 //! struct MyError;
@@ -68,10 +68,20 @@
 //! let data = vec![1, 2, 3];
 //! let error = MyError::attach_kv(ty!(Vec<i32>), data.len());
 //!
-//! // Using macros for convenience
-//! let username = "alice";
-//! let error = MyError::attach(kv!(username)); // "username": "alice"
-//! let error = MyError::attach(kv!(ty: username));  // <&str>: "alice"
+//! #[derive(Debug, Clone, Eq, PartialEq)]
+//! struct Username(String);
+//! impl std::fmt::Display for Username {
+//!     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//!         write!(f, "{}", self.0)
+//!     }
+//! }
+//!
+//! let username = String::from("alice");
+//! assert_eq!(kv!(username.clone()), KeyValue("username", String::from("alice")));
+//! let error = MyError::attach(kv!(username.clone())); // "username": "alice"
+//!
+//! let username = Username(username);
+//! assert_eq!(format!("{}", kv!(ty: username)), "Username: alice");
 //! ```
 //!
 //! ## Conversion and Propagation

--- a/bigerror/src/lib.rs
+++ b/bigerror/src/lib.rs
@@ -1571,6 +1571,7 @@ impl<T> OptionReport<T> for Option<T> {
     }
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! __field {
     ({ } @[$field:ident] ref[$($ref:tt)*] var[$($var:tt)+] fns[$($fn:tt)*]) => {

--- a/bigerror/src/lib.rs
+++ b/bigerror/src/lib.rs
@@ -81,7 +81,7 @@
 //! let error = MyError::attach(kv!(username.clone())); // "username": "alice"
 //!
 //! let username = Username(username);
-//! assert_eq!(format!("{}", kv!(ty: username)), "Username: alice");
+//! assert_eq!(format!("{}", kv!(ty: username)), "<Username>: alice");
 //! ```
 //!
 //! ## Conversion and Propagation

--- a/bigerror/src/lib.rs
+++ b/bigerror/src/lib.rs
@@ -521,7 +521,7 @@ pub trait IntoContext {
     /// struct AppError;
     ///
     /// fn load_config() -> Result<i32, Report<ConfigError>> {
-    ///     "42".parse().into_ctx::<ConfigError>()
+    ///     "42".parse().into_ctx()
     /// }
     ///
     /// fn start_app() -> Result<(), Report<AppError>> {

--- a/bigerror/src/lib.rs
+++ b/bigerror/src/lib.rs
@@ -606,6 +606,7 @@ pub trait AttachExt {
     ///         error = Some(ValidationError::attach("validation failed")
     ///             .attach_field_status("email", Missing));
     ///     }
+    ///     Ok(())
     /// }
     /// ```
     #[must_use]
@@ -622,26 +623,17 @@ pub trait AttachExt {
     /// # Example
     ///
     /// ```
-    /// use bigerror::{AttachExt, ThinContext, Report};
+    /// use bigerror::{AttachExt, ThinContext, Report, DecodeError};
     ///
-    /// #[derive(ThinContext)]
-    /// struct ProcessingError;
-    ///
-    /// #[derive(Debug)]
-    /// struct Data {
-    ///     data: Vec<u8>,
-    ///     flags: u32,
-    /// }
-    ///
-    /// fn process_data(data: Data) -> Result<String, Report<ProcessingError>> {
-    ///     if state.data.is_empty() {
-    ///         return Err(ProcessingError::attach("processing failed"))
-    ///             .attach_dbg(state); // Attach the entire state for debugging
+    /// fn decode_data(data: &mut Vec<u8>) -> Result<&str, Report<DecodeError>> {
+    ///     if data.is_empty() {
+    ///         return Err(DecodeError::attach("no data found"))
+    ///             .attach_dbg(data.clone());
     ///     }
     ///
     ///     // ...
     ///
-    ///     Ok(String::from("data processed"));
+    ///     Ok("data processed")
     /// }
     /// ```
     #[must_use]


### PR DESCRIPTION
This PR refactors the `kv` and `expect_field` macro to use the same `__field` token processing backend.